### PR TITLE
[SDPAA-816] Added support for database images.

### DIFF
--- a/assets/.ahoy.yml
+++ b/assets/.ahoy.yml
@@ -43,6 +43,11 @@ commands:
   up:
     usage: Build and start Docker containers.
     cmd: |
+      # Log into to Github docker registry if custom MYSQL_IMAGE is set.
+      if [ "$MYSQL_IMAGE" ]; then
+        GITHUB_USER=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user | jq -r .login)
+        echo $GITHUB_TOKEN | docker login docker.pkg.github.com -u "${GITHUB_USER}" --password-stdin
+      fi
       docker-compose up -d "$@" \
       && ahoy cli "dockerize -wait tcp://mariadb:3306 -timeout 1m" \
       && if docker-compose logs | grep -q "\[Error\]"; then docker-compose logs; exit 1; fi \
@@ -116,6 +121,9 @@ commands:
       ahoy flush-redis
       if [ "$INSTALL_NEW_SITE" == "1" ]; then
         ahoy cli -- ./scripts/drupal/install-new-site.sh
+      elif [ "${MYSQL_IMAGE}" ]; then
+        ahoy line "DB image ${MYSQL_IMAGE} in use - skipping sync"
+        ahoy cli -- ./scripts/drupal/deploy.sh
       else
         ahoy cli -- ./scripts/rebuild-env.sh
       fi


### PR DESCRIPTION
Related to https://github.com/dpc-sdp/dev-tools/pull/33

There are a few differences between this PR and that one.

- `sdp-platform` does not currently ship a `.env` file, which makes sense as its all project-specific.
- `sdp-platform` does not currently ship a `docker-compose.yml` file as the `AUTHENTICATED_CONTENT` environment variable is needed, and docker-compose does not support multi-line values in .env files - see https://digital-engagement.atlassian.net/browse/DDIDO-258
- `sdp-platform` does not ship a README.md file. Maybe it should, or at least ship some generic documentation and leave project-specifc information in another file.