### PR TITLE
Unset arg assigment and assigned default.

### DIFF
--- a/assets/.docker/Dockerfile.cli
+++ b/assets/.docker/Dockerfile.cli
@@ -1,4 +1,4 @@
-ARG BAY_IMAGE_VERSION=latest
+ARG BAY_IMAGE_VERSION
 
 # @see https://github.com/dpc-sdp/bay/blob/master/bay/images/Dockerfile.php
 FROM singledigital/bay-cli:${BAY_IMAGE_VERSION}

--- a/assets/.docker/Dockerfile.nginx-drupal
+++ b/assets/.docker/Dockerfile.nginx-drupal
@@ -1,9 +1,9 @@
 # @see https://github.com/dpc-sdp/bay/blob/master/bay/images/Dockerfile.nginx
-ARG BAY_IMAGE_VERSION=latest
+ARG BAY_IMAGE_VERSION
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE:-cli} as cli
 
-FROM singledigital/bay-nginx:${BAY_IMAGE_VERSION}
+FROM singledigital/bay-nginx:${BAY_IMAGE_VERSION:-latest}
 
 ENV WEBROOT=docroot
 

--- a/assets/.docker/Dockerfile.php
+++ b/assets/.docker/Dockerfile.php
@@ -1,8 +1,8 @@
 # @see https://github.com/dpc-sdp/bay/blob/master/bay/images/Dockerfile.php
-ARG BAY_IMAGE_VERSION=latest
+ARG BAY_IMAGE_VERSION
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE:-cli} as cli
 
-FROM singledigital/bay-php:${BAY_IMAGE_VERSION}
+FROM singledigital/bay-php:${BAY_IMAGE_VERSION:-latest}
 
 COPY --from=cli /app /app


### PR DESCRIPTION
### Changes
1. Removes argument assignment and assign default so that the Lagoon env var is consumed and these templates don't need to be updated every time there's a release.

I've decided to assign the default so builds don't break based on there being limited risk that the env var isn't set and the `latest` tag pointing to HEAD of master.